### PR TITLE
Support windows stack builds

### DIFF
--- a/tasks/stacks/build-stack-image-windows/run
+++ b/tasks/stacks/build-stack-image-windows/run
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-build_args=$(cat "${BUILD_ARGS_FILE}" | awk '{printf " --build-arg \"%s\"", $0}')
-build_str="docker build${build_args} --no-cache -t img "${CONTEXT}" ; docker save -o image/image.tar img"
-echo ${build_str}
-eval ${build_str}
+build_args=$(cat "${BUILD_ARGS_FILE}" | awk '{printf " --build-arg %s", $0}')
+echo "Build args:"
+echo ${build_args}
+docker build${build_args} --no-cache -t img "${CONTEXT}"
+docker save -o image/image.tar img

--- a/tasks/stacks/build-stack-image-windows/run
+++ b/tasks/stacks/build-stack-image-windows/run
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+build_args=$(cat "${BUILD_ARGS_FILE}" | awk '{printf " --build-arg \"%s\"", $0}')
+build_str="docker build${build_args} --no-cache -t img "${CONTEXT}" ; docker save -o image/image.tar img"
+echo ${build_str}
+eval ${build_str}

--- a/tasks/stacks/build-stack-image-windows/task.yml
+++ b/tasks/stacks/build-stack-image-windows/task.yml
@@ -1,0 +1,23 @@
+---
+  platform: windows
+  
+  inputs:
+    - name: core-deps-ci
+    - name: stacks
+    - name: build-args
+      optional: true
+    - name: docker_creds
+      optional: true
+
+  run:
+    path: bash
+    args:
+      - core-deps-ci\tasks\stacks\build-stack-image-windows\run
+  
+  outputs:
+    - name: image
+
+  params:
+    CONTEXT:
+    BUILD_ARGS_FILE:
+    DOCKER_CONFIG: docker_creds

--- a/tasks/stacks/write-build-args-file/run
+++ b/tasks/stacks/write-build-args-file/run
@@ -11,12 +11,19 @@ if [[ "${STACK_ID}" != "" ]]; then
 fi
 
 if [[ -d mixins-label ]]; then
-  echo "mixins=$(cat mixins-label/*)" >> build-args/args
+  echo "mixins=$(cat mixins-label/*-mixins.json)" >> build-args/args
 else
   echo "mixins=[]" >> build-args/args
 fi
 
-if [[ "${STACK}" != "" && "${IMAGE}" != "" && -d stacks ]]; then
+if [[ "${WINDOWS}" == "" && "${STACK}" != "" && "${IMAGE}" != "" && -d stacks ]]; then
   echo "sources=$(cat stacks/arch/x86_64/* | tr '\n' '#' | sed 's/#/\\n/g')" >> build-args/args
   echo "packages=$(cat "stacks/packages/${STACK}/${IMAGE}" | tr '\n' ' ')" >> build-args/args
 fi
+
+if [[ "${WINDOWS}" != ""  && -f "stacks/${STACK}/dockerfile/${IMAGE}/windows-features" ]]; then
+  echo "windows_features=$(cat stacks/${STACK}/dockerfile/${IMAGE}/windows-features | xargs)" >> build-args/args
+fi
+
+echo "Generated build args:"
+cat build-args/args

--- a/tasks/stacks/write-build-args-file/run
+++ b/tasks/stacks/write-build-args-file/run
@@ -22,7 +22,7 @@ if [[ "${WINDOWS}" == "" && "${STACK}" != "" && "${IMAGE}" != "" && -d stacks ]]
 fi
 
 if [[ "${WINDOWS}" != ""  && -f "stacks/${STACK}/dockerfile/${IMAGE}/windows-features" ]]; then
-  echo "windows_features=$(cat stacks/${STACK}/dockerfile/${IMAGE}/windows-features | xargs)" >> build-args/args
+  echo "windows_features=$(cat stacks/${STACK}/dockerfile/${IMAGE}/windows-features | xargs | tr ' ' ',')" >> build-args/args
 fi
 
 echo "Generated build args:"

--- a/tasks/stacks/write-build-args-file/task.yml
+++ b/tasks/stacks/write-build-args-file/task.yml
@@ -21,4 +21,5 @@ params:
   BASE_IMAGE:
   STACK_ID:
   STACK:
-  IMAGE:
+  IMAGE: 
+  WINDOWS:

--- a/tasks/stacks/write-mixins-labels/run
+++ b/tasks/stacks/write-mixins-labels/run
@@ -2,12 +2,18 @@
 
 set -euo pipefail
 
-sort -u build-image-package-list/package-list -o build-image-package-list/package-list
-sort -u run-image-package-list/package-list -o run-image-package-list/package-list
+if [ -d "build-image-package-list" ] && [ -d "run-image-package-list" ]; then
+  sort -u build-image-package-list/package-list -o build-image-package-list/package-list
+  sort -u run-image-package-list/package-list -o run-image-package-list/package-list
 
-shared_packages="$(comm -12 build-image-package-list/package-list run-image-package-list/package-list)"
-build_only_packages="$(comm -23 build-image-package-list/package-list run-image-package-list/package-list)"
-run_only_packages="$(comm -13 build-image-package-list/package-list run-image-package-list/package-list)"
+  shared_packages="$(comm -12 build-image-package-list/package-list run-image-package-list/package-list)"
+  build_only_packages="$(comm -23 build-image-package-list/package-list run-image-package-list/package-list)"
+  run_only_packages="$(comm -13 build-image-package-list/package-list run-image-package-list/package-list)"
+else
+  shared_packages=""
+  build_only_packages=""
+  run_only_packages=""
+fi
 
 additional_build_mixins="$(cat "build-base-dockerfile/${STACK}/cnb/build/additional-mixins")"
 additional_run_mixins="$(cat "run-base-dockerfile/${STACK}/cnb/run/additional-mixins")"
@@ -30,3 +36,7 @@ EOF
 
 echo "${build_mixins_label}" | jq -cnR '[inputs | select(length>0)]' > build-mixins-label/mixins.json
 echo "${run_mixins_label}" | jq -cnR '[inputs | select(length>0)]' > run-mixins-label/mixins.json
+
+echo "Wrote mixins..."
+cat build-mixins-label/mixins.json
+cat run-mixins-label/mixins.json

--- a/tasks/stacks/write-mixins-labels/run
+++ b/tasks/stacks/write-mixins-labels/run
@@ -37,6 +37,7 @@ EOF
 echo "${build_mixins_label}" | jq -cnR '[inputs | select(length>0)]' > build-mixins-label/mixins.json
 echo "${run_mixins_label}" | jq -cnR '[inputs | select(length>0)]' > run-mixins-label/mixins.json
 
-echo "Wrote mixins..."
+echo "Wrote build mixins..."
 cat build-mixins-label/mixins.json
+echo "Wrote run mixins..."
 cat run-mixins-label/mixins.json

--- a/tasks/stacks/write-mixins-labels/task.yml
+++ b/tasks/stacks/write-mixins-labels/task.yml
@@ -8,7 +8,9 @@ image_resource:
 inputs:
 - name: core-deps-ci
 - name: build-image-package-list
+  optional: true
 - name: run-image-package-list
+  optional: true
 - name: build-base-dockerfile
 - name: run-base-dockerfile
 


### PR DESCRIPTION
Updates/adds the following tasks to support windows builds:

- `build-stack-image-windows` (similar functionality to `build-stack-image` for linux)
- `write-build-args-file` (supports values for windows)
- `write-mixins-label` (makes non-windows inputs optional)