### PR TITLE
Add pipeline for cflinuxfs4

### DIFF
--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -11,390 +11,709 @@ params:
 
 ---
 resource_types:
-  - name: slack-notification
-    type: docker-image
-    source:
-      repository: cfcommunity/slack-notification-resource
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
 
-  - name: bosh-deployment
-    type: docker-image
-    source:
-      repository: cloudfoundry/bosh-deployment-resource
+- name: bosh-deployment
+  type: docker-image
+  source:
+    repository: cloudfoundry/bosh-deployment-resource
 
 resources:
-  - name: buildpacks-ci
-    type: git
-    source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
-      branch: master
+- name: cf-deployment-concourse-tasks
+  type: git
+  source:
+    branch: main
+    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
+    tag_filter: v8.*
 
-  - name: cflinuxfs4
-    type: git
-    source:
-      uri: git@github.com:cf-buildpacks-eng/cflinuxfs4
-      branch: main
-      private_key: ((cf-buildpacks-eng-github-ssh-key.private_key))
+- name: cf-deployment-concourse-tasks-latest
+  type: git
+  source:
+    branch: main
+    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
 
-  - name: cflinuxfs4-github-tags
-    type: git
-    source:
-      uri: git@github.com:cf-buildpacks-eng/cflinuxfs4
-      private_key: ((cf-buildpacks-eng-github-ssh-key.private_key))
-      tag_filter: "*"
+- name: bbl-state
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/buildpacks-envs
+    branch: master
+    private_key: ((buildpacks-envs-deploy-key.private_key))
 
-  - name: cflinuxfs4-build-trigger
-    type: git
-    source:
-      uri: git@github.com:cf-buildpacks-eng/cflinuxfs4
-      private_key: ((cf-buildpacks-eng-github-ssh-key.private_key))
-      ignore_paths:
-        - receipt.cflinuxfs4.x86_64
-        - README.md
-        - .gitignore
+- name: bosh-deployment
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/bosh-deployment.git
+    branch: master
 
-  - name: receipt-diff
-    type: git
-    source:
-      uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
-      paths: [ receipt.cflinuxfs4.x86_64 ]
-      private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
-      tag_filter: "newpackages_cflinuxfs4_*"
+- name: cf-deployment
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/cf-deployment
+    branch: main
 
-  - name: new-cves
-    type: git
-    source:
-      uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
-      paths: [ new-cve-notifications/ubuntu22.04.yml ]
-      private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
-      branch: main
+- name: buildpacks-ci
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/buildpacks-ci
+    branch: master
 
-  - name: public-robots
-    type: git
-    source:
-      uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
-      private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
-      branch: main
+- name: cflinuxfs4
+  type: git
+  source:
+    branch: main
+    uri: git@github.com:cloudfoundry/cflinuxfs4.git
+    private_key: ((cflinuxfs4-deploy-key.private_key))
 
-  - name: stack-s3
-    type: s3
-    source:
-      bucket: pivotal-buildpacks
-      regexp: rootfs/cflinuxfs4-(.*).tar.gz
-      access_key_id: ((pivotal-buildpacks-s3-access-key))
-      secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+- name: cflinuxfs4-github-tags
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/cflinuxfs4.git
+    private_key: ((cflinuxfs4-deploy-key.private_key))
+    tag_filter: "*"
 
-  - name: receipt-s3
-    type: s3
-    source:
-      bucket: pivotal-buildpacks
-      regexp: rootfs/receipt.cflinuxfs4.x86_64-(.*)
-      access_key_id: ((pivotal-buildpacks-s3-access-key))
-      secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+- name: cflinuxfs4-build-trigger
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/cflinuxfs4.git
+    private_key: ((cflinuxfs4-deploy-key.private_key))
+    ignore_paths:
+    - receipt.cflinuxfs4.x86_64
+    - README.md
+    - .gitignore
 
-  - name: cflinuxfs4-image
-    type: docker-image
-    source:
-      repository: cfbuildpacks/cflinuxfs4
-      username: ((cfbuildpacks-dockerhub-user.username))
-      password: ((cfbuildpacks-dockerhub-user.password))
-      email: cf-buildpacks-eng@pivotal.io
+- name: new-cves
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
+    paths: [ new-cve-notifications/ubuntu22.04.yml ]
+    private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
+    branch: main
 
-  - name: cflinuxfs4-github-release
-    type: github-release
-    source:
-      drafts: false
-      user: cf-buildpacks-eng
-      repository: cflinuxfs4
-      access_token: ((buildpacks-github-token))
+- name: receipt-diff
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
+    paths: [ receipt.cflinuxfs4.x86_64 ]
+    private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
+    tag_filter: "newpackages_cflinuxfs4_*"
 
-  - name: version
-    type: semver
-    source:
-      bucket: pivotal-buildpacks
-      key: versions/stack-cflinuxfs4
-      access_key_id: ((pivotal-buildpacks-s3-access-key))
-      secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+- name: public-robots
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
+    private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
+    branch: main
 
-  - name: failure-alert
-    type: slack-notification
-    source:
-      url: ((concourse-job-failure-notifications-slack-webhook))
+- name: cflinuxfs4-release
+  type: git
+  source:
+    branch: main
+    uri: git@github.com:cloudfoundry/cflinuxfs4-release.git
+    private_key: ((cflinuxfs4-release-deploy-key.private_key))
+
+- name: capi-release
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/capi-release
+    branch: main
+
+- name: stack-s3
+  type: s3
+  source:
+    bucket: pivotal-buildpacks
+    regexp: rootfs/cflinuxfs4-(.*).tar.gz
+    access_key_id: ((pivotal-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+
+- name: receipt-s3
+  type: s3
+  source:
+    bucket: pivotal-buildpacks
+    regexp: rootfs/receipt.cflinuxfs4.x86_64-(.*)
+    access_key_id: ((pivotal-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+
+- name: cflinuxfs4-cf-deployment
+  type: bosh-deployment
+  source:
+    deployment: cf
+    skip_check: true
+
+- name: cflinuxfs4-rootfs-smoke-test-deployment
+  type: bosh-deployment
+  source:
+    skip_check: true
+    deployment: rootfs-smoke-test
+
+- name: gcp-stemcell
+  type: bosh-io-stemcell
+  source:
+    name: bosh-google-kvm-ubuntu-bionic-go_agent
+
+- name: cflinuxfs4-image
+  type: docker-image
+  source:
+    #! Later TODO: move to cloudfoundry for cosmetic purposes
+    repository: cfbuildpacks/cflinuxfs4
+    username: ((cfbuildpacks-dockerhub-user.username))
+    password: ((cfbuildpacks-dockerhub-user.password))
+    email: cf-buildpacks-eng@pivotal.io
+
+- name: cflinuxfs4-github-release
+  type: github-release
+  source:
+    drafts: false
+    user: cloudfoundry
+    repository: cflinuxfs4
+    access_token: ((buildpacks-github-token))
+
+- name: cflinuxfs4-release-github-release
+  type: github-release
+  source:
+    drafts: false
+    user: cloudfoundry
+    repository: cflinuxfs4-release
+    access_token: ((buildpacks-github-token))
+
+- name: version
+  type: semver
+  source:
+    bucket: pivotal-buildpacks
+    key: versions/stack-cflinuxfs4
+    access_key_id: ((pivotal-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+
+- name: test-go-buildpack
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/go-buildpack
+    branch: hacky-cflinuxfs4
+
+- name: failure-alert
+  type: slack-notification
+  source:
+    url: ((concourse-job-failure-notifications-slack-webhook))
 
 jobs:
-  - name: build-rootfs
-    serial: true
-    serial_groups: [ cflinuxfs4 ]
-    public: true
-    plan:
-      - in_parallel:
-          - get: previous-rootfs-release
-            resource: cflinuxfs4-github-tags
-          - get: buildpacks-ci
-          - get: new-cves
-            trigger: true
-          - get: rootfs
-            resource: cflinuxfs4
-          - get: cflinuxfs4-build-trigger
-            trigger: true
-          - get: version
-            params: { pre: rc }
-          - get: public-robots
-      - do:
-          - task: make-rootfs
-            file: buildpacks-ci/tasks/make-rootfs/task.yml
-            privileged: true
-            params:
-              STACK: cflinuxfs4
-          - put: stack-s3
-            params:
-              file: rootfs-artifacts/cflinuxfs4-*.tar.gz
-          - put: receipt-s3
-            params:
-              file: receipt-artifacts/receipt.cflinuxfs4.x86_64-*
-          - task: generate-receipt-diff
-            file: buildpacks-ci/tasks/generate-rootfs-receipt-diff/task.yml
-            params:
-              STACK: cflinuxfs4
-          - put: public-robots
-            params:
-              repository: public-robots-artifacts
-              rebase: true
-              tag: git-tags/TAG
-          - put: version
-            params: { file: version/number }
-        on_failure: #@ failure_alert()
+- name: build-rootfs
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: previous-rootfs-release
+      resource: cflinuxfs4-github-tags
+    - get: buildpacks-ci
+    - get: new-cves
+      trigger: true
+    - get: rootfs
+      resource: cflinuxfs4
+    - get: cflinuxfs4-build-trigger
+      trigger: true
+    - get: version
+      params: { pre: rc }
+    - get: public-robots
+  - do:
+    - task: make-rootfs
+      file: buildpacks-ci/tasks/make-rootfs/task.yml
+      privileged: true
+      params:
+        STACK: cflinuxfs4
+    - put: stack-s3
+      params:
+        file: rootfs-artifacts/cflinuxfs4-*.tar.gz
+    - put: receipt-s3
+      params:
+        file: receipt-artifacts/receipt.cflinuxfs4.x86_64-*
+    - task: generate-receipt-diff
+      file: buildpacks-ci/tasks/generate-rootfs-receipt-diff/task.yml
+      params:
+        STACK: cflinuxfs4
+    - put: public-robots
+      params:
+        repository: public-robots-artifacts
+        rebase: true
+        tag: git-tags/TAG
+    - put: version
+      params: { file: version/number }
+    on_failure: #@ failure_alert()
 
-  - name: bbl-up-wip
-    serial: true
-    serial_groups: [ cflinuxfs4 ]
-    public: true
-    plan:
-      - in_parallel:
-          - get: previous-rootfs-release
-            resource: cflinuxfs4-github-tags
-            passed: [ build-rootfs ]
-          - get: receipt-diff
-            trigger: true
-          - get: new-cves
-            passed: [ build-rootfs ]
-          - get: stack-s3
-            passed: [ build-rootfs ]
-          - get: version
-            passed: [ build-rootfs ]
-          - get: receipt-s3
-            passed: [ build-rootfs ]
-          - get: rootfs
-            resource: cflinuxfs4
-            passed: [ build-rootfs ]
+- name: bbl-up
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: previous-rootfs-release
+      resource: cflinuxfs4-github-tags
+      passed: [ build-rootfs ]
+    - get: cf-deployment-concourse-tasks
+      resource: cf-deployment-concourse-tasks-latest
+    - get: bbl-state
+    - get: bbl-config
+      resource: bbl-state
+    - get: bosh-deployment
+    - get: buildpacks-ci
+    - get: receipt-diff
+      trigger: true
+    - get: new-cves
+      passed: [ build-rootfs ]
+    - get: stack-s3
+      passed: [ build-rootfs ]
+    - get: version
+      passed: [ build-rootfs ]
+    - get: receipt-s3
+      passed: [ build-rootfs ]
+    - get: rootfs
+      resource: cflinuxfs4
+      passed: [ build-rootfs ]
+  - task: bbl-up
+    file: cf-deployment-concourse-tasks/bbl-up/task.yml
+    params:
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
+      BBL_GCP_PROJECT_ID: cf-buildpacks
+      BBL_GCP_ZONE: us-east1-c
+      BBL_GCP_REGION: us-east1
+      BBL_IAAS: gcp
+      BBL_LB_CERT: ((cflinuxfs4-lb-cert.certificate))
+      BBL_LB_KEY: ((cflinuxfs4-lb-cert.private_key))
+      LB_DOMAIN: cflinuxfs4.buildpacks-gcp.ci.cf-app.com
+      BBL_ENV_NAME: cflinuxfs4
+      BBL_STATE_DIR: cflinuxfs4
+    input_mapping:
+      ops-files: bosh-deployment
+    ensure:
+      put: bbl-state
+      params:
+        repository: updated-bbl-state
+        rebase: true
+  - task: add-gcp-parent-dns-record
+    file: buildpacks-ci/tasks/add-gcp-parent-dns-record/task.yml
+    params:
+      ENV_NAME: cflinuxfs4
+      GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
 
-  - name: deploy-wip
-    serial: true
-    serial_groups: [ cflinuxfs4 ]
-    public: true
-    plan:
-      - do:
-          - in_parallel:
-              - get: new-cves
-                passed: [ bbl-up-wip ]
-              - get: stack-s3
-                passed: [ bbl-up-wip ]
-              - get: version
-                passed: [ bbl-up-wip ]
-                trigger: true
-              - get: receipt-s3
-                passed: [ bbl-up-wip ]
-              - get: rootfs
-                resource: cflinuxfs4
-                passed: [ bbl-up-wip ]
-              - get: previous-rootfs-release
-                resource: cflinuxfs4-github-tags
-                passed: [ bbl-up-wip ]
-              - get: buildpacks-ci
-
-  - name: cats-wip
-    serial: true
-    serial_groups: [ cflinuxfs4 ]
-    public: true
-    plan:
-      - in_parallel:
-          - get: buildpacks-ci
-          - get: previous-rootfs-release
-            resource: cflinuxfs4-github-tags
-            passed: [ deploy-wip ]
-          - get: new-cves
-            passed: [ deploy-wip ]
-          - get: stack-s3
-            passed: [ deploy-wip ]
-          - get: version
-            passed: [ deploy-wip ]
-            trigger: true
-          - get: receipt-s3
-            passed: [ deploy-wip ]
-          - get: rootfs
-            resource: cflinuxfs4
-            passed: [ deploy-wip ]
-
-  - name: check-for-race-condition
-    serial: true
-    serial_groups: [ cflinuxfs4 ]
-    public: true
-    plan:
-      - in_parallel:
-          - get: buildpacks-ci
-          - get: version
-            passed: [ cats-wip ]
-            trigger: true
-          - get: latest-version
-            resource: version
-          - get: previous-rootfs-release
-            resource: cflinuxfs4-github-tags
-            passed: [ cats-wip ]
-          - get: new-cves
-            passed: [ cats-wip ]
-          - get: stack-s3
-            passed: [ cats-wip ]
-          - get: receipt-s3
-            passed: [ cats-wip ]
-          - get: rootfs
-            resource: cflinuxfs4
-            passed: [ cats-wip ]
-      - task: check-for-rootfs-race-condition
-        file: buildpacks-ci/tasks/check-for-rootfs-race-condition/task.yml
-
-  - name: release-cflinuxfs4
-    serial: true
-    serial_groups: [ cflinuxfs4 ]
-    public: true
-    plan:
-      - in_parallel:
-          - get: buildpacks-ci
-          - get: new-cves
-            passed: [ check-for-race-condition ]
-          - get: stack-s3
-            passed: [ check-for-race-condition ]
-          - get: receipt-s3
-            passed: [ check-for-race-condition ]
-          - get: rootfs
-            resource: cflinuxfs4
-            passed: [ check-for-race-condition ]
-          - get: version
-            trigger: true
-            passed: [ check-for-race-condition ]
-            params: { bump: final }
-          - get: previous-rootfs-release
-            resource: cflinuxfs4-github-tags
-            passed: [ check-for-race-condition ]
-      - do:
-          - task: update-receipt
-            file: buildpacks-ci/tasks/update-rootfs-receipt/task.yml
-            params:
-              STACK: cflinuxfs4
-          - task: update-filename
-            file: buildpacks-ci/tasks/update-rootfs-filename/task.yml
-            params:
-              STACK: cflinuxfs4
-          - put: cflinuxfs4
-            params:
-              repository: new-rootfs-commit
-              tag: version/number
-              rebase: true
-          - put: stack-s3
-            params:
-              from: rootfs-archive/cflinuxfs4-(.*).tar.gz
-              to: /rootfs/
-          - put: version
-            params: { file: version/number }
-        on_failure: #@ failure_alert()
-
-  - name: reset-minor-version-to-rc
-    serial: true
-    public: true
-    plan:
+- name: deploy
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - do:
+    - in_parallel:
+      - get: new-cves
+        passed: [ bbl-up ]
+      - get: stack-s3
+        passed: [ bbl-up ]
       - get: version
+        passed: [ bbl-up ]
         trigger: true
-        passed: [ release-cflinuxfs4 ]
-        params: { bump: minor, pre: rc }
-      - put: version
-        params: { file: version/number }
+      - get: receipt-s3
+        passed: [ bbl-up ]
+      - get: rootfs
+        resource: cflinuxfs4
+        passed: [ bbl-up ]
+      - get: previous-rootfs-release
+        resource: cflinuxfs4-github-tags
+        passed: [ bbl-up ]
+      - get: rootfs-release
+        resource: cflinuxfs4-release
+      - get: buildpacks-ci
+      - get: capi-release
+      - get: bbl-state
+      - get: cf-deployment
+      - get: gcp-stemcell
+      - get: cf-deployment-concourse-tasks
+      - get: bosh-deployment
 
-  - name: upload-to-github
-    serial: true
-    public: true
-    plan:
-      - in_parallel:
-          - get: buildpacks-ci
-          - get: previous-rootfs-release
-            resource: cflinuxfs4-github-tags
-            passed: [ release-cflinuxfs4 ]
-          - get: rootfs
-            resource: cflinuxfs4
-            passed: [ release-cflinuxfs4 ]
-          - get: new-cves
-            passed: [ release-cflinuxfs4 ]
-          - get: stack-s3
-            passed: [ release-cflinuxfs4 ]
-          - get: version
-            trigger: true
-            passed: [ release-cflinuxfs4 ]
-      - do:
-          - task: generate-release-notes
-            file: buildpacks-ci/tasks/generate-rootfs-release-notes/task.yml
-            params:
-              STACK: cflinuxfs4
-          - put: cflinuxfs4-github-release
-            params:
-              name: version/number
-              tag: version/number
-              body: release-body/body
-              globs:
-                - stack-s3/cflinuxfs4-*.tar.gz
-          - put: new-cves
-            params:
-              repository: new-cves-artifacts
-              rebase: true
-        on_failure: #@ failure_alert()
+    - in_parallel:
+      - task: create-deployment-source-config
+        file: buildpacks-ci/tasks/create-deployment-source-config/task.yml
+        params:
+          ENV_NAME: cflinuxfs4
+      - task: overwrite-rootfs-release
+        file: buildpacks-ci/tasks/overwrite-rootfs-release/task.yml
+        params:
+          STACK: cflinuxfs4
+      - task: create-capi-release-with-rootfs
+        file: buildpacks-ci/tasks/create-capi-release-with-rootfs/task.yml
+        params:
+          STACK: cflinuxfs4
+    - put: cflinuxfs4-rootfs-smoke-test-deployment
+      params:
+        source_file: deployment-source-config/source_file.yml
+        manifest: rootfs-release-artifacts/manifests/manifest.yml
+        releases:
+        - rootfs-release-artifacts/dev_releases/cflinuxfs4/*.tgz
+        stemcells:
+        - gcp-stemcell/*.tgz
+    - task: run-rootfs-smoke-test
+      file: buildpacks-ci/tasks/run-rootfs-smoke-test/task.yml
+      params:
+        ENV_NAME: cflinuxfs4
+    - put: cflinuxfs4-cf-deployment
+      params:
+        source_file: deployment-source-config/source_file.yml
+        manifest: cf-deployment/cf-deployment.yml
+        releases:
+        - rootfs-release-artifacts/dev_releases/cflinuxfs4/*.tgz
+        - capi-release-artifacts/dev_releases/capi/*.tgz
+        stemcells:
+        - gcp-stemcell/*.tgz
+        ops_files:
+        - buildpacks-ci/deployments/operations/no-canaries.yml
+        #! Because currently cflinuxfs3 is the default in cf-deployment
+        - buildpacks-ci/deployments/operations/substitute-with-cflinuxfs4-trusted-certs.yml
+        #! We do not have cflinuxfs4 based buildpacks yet
+        - buildpacks-ci/deployments/operations/do-not-pre-install-buildpacks.yml
+        #! temporary because we need https://github.com/cloudfoundry/garden-runc-release/pull/229
+        - buildpacks-ci/deployments/operations/use-garden-runc-1-20.7.yml
+        - rootfs-release-artifacts/use-dev-release-opsfile.yml
+        - capi-release-artifacts/use-dev-release-opsfile.yml
+        - capi-release-artifacts/use-rootfs-as-default-stack.yml
+        - cf-deployment/operations/use-latest-stemcell.yml
+        - cf-deployment/operations/disable-dynamic-asgs.yml
+        vars:
+          system_domain: cflinuxfs4.buildpacks-gcp.ci.cf-app.com
+    on_failure: #@ failure_alert()
 
-  - name: upload-to-docker
-    serial: true
-    public: true
-    plan:
-      - in_parallel:
-          - get: buildpacks-ci
-          - get: stack-s3
-            passed: [ release-cflinuxfs4 ]
-          - get: version
-            trigger: true
-            passed: [ release-cflinuxfs4 ]
-      - do:
-          - task: rename
-            file: buildpacks-ci/tasks/rename-rootfs-for-docker/task.yml
-            params:
-              STACK: cflinuxfs4
-          - in_parallel:
-              - put: cflinuxfs4-image
-                params:
-                  skip_download: true
-                  import_file: docker-s3/cflinuxfs4.tar.gz
-                  tag: version/number
-                  tag_as_latest: true
-        on_failure: #@ failure_alert()
+- name: test
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: test-go-buildpack
+    - get: bbl-state
+    - get: buildpacks-ci
+    - get: previous-rootfs-release
+      resource: cflinuxfs4-github-tags
+      passed: [ deploy ]
+    - get: new-cves
+      passed: [ deploy ]
+    - get: stack-s3
+      passed: [ deploy ]
+    - get: version
+      passed: [ deploy ]
+      trigger: true
+    - get: receipt-s3
+      passed: [ deploy ]
+    - get: rootfs
+      resource: cflinuxfs4
+      passed: [ deploy ]
+  - do:
+    - task: get-cf-creds
+      file: buildpacks-ci/tasks/get-cf-creds/task.yml
+      params:
+        ENV_NAME: cflinuxfs4
+    - task: run-test
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: cfbuildpacks/ci
+        inputs:
+        - name: test-go-buildpack
+        - name: cf-admin-password
+        run:
+          dir: ""
+          path: bash
+          args:
+          - -c
+          - |
+            #!/bin/bash
+            set -e
+            password=$(cat cf-admin-password/password)
+            apps_domain="cflinuxfs4.buildpacks-gcp.ci.cf-app.com"
+            cf api api.${apps_domain} --skip-ssl-validation
+            cf login -u admin -p "${password}"
+            cf target -o system
+            cf create-space my-space
+            cf target -s my-space
 
-  - name: finalize-security-notices
-    serial: true
-    public: true
-    plan:
-      - in_parallel:
-          - get: buildpacks-ci
-            resource: buildpacks-ci
-          - get: version
-            trigger: true
-            passed: [ upload-to-github ]
-      - do:
-          - task: finalize-security-notices
-            file: buildpacks-ci/tasks/finalize-security-notice-stories/task.yml
-            attempts: 20
-            params:
-              TRACKER_PROJECT_ID: 2537714
-              TRACKER_REQUESTER_ID: 1431988
-              TRACKER_API_TOKEN: ((pivotal-tracker-api-token))
-              STACK: cflinuxfs4
+            pushd test-go-buildpack
+              ./scripts/package.sh --stack cflinuxfs4 --version 222.2.2
+              cf create-buildpack go_cflinuxfs4 ./build/buildpack.zip 1
+
+              cf push gomodapp -p fixtures/mod/simple -b go_cflinuxfs4 -s cflinuxfs4 | tee /tmp/cfpushlog
+              if ! grep -q "Description:\s*Ubuntu 22.04 LTS" "/tmp/cfpushlog"; then
+                echo "cf push logs did not print out 'Ubuntu 22.04'"
+                exit 1
+              fi
+
+              result=$(curl -s "gomodapp.${apps_domain}" | head -n1)
+              if [ "${result}" != "go, world" ]; then
+                echo "Unexpected result: ${result}"
+                exit 1
+              fi
+            popd
+    on_failure: #@ failure_alert()
+
+- name: check-for-race-condition
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: version
+      passed: [ test ]
+      trigger: true
+    - get: latest-version
+      resource: version
+    - get: previous-rootfs-release
+      resource: cflinuxfs4-github-tags
+      passed: [ test ]
+    - get: new-cves
+      passed: [ test ]
+    - get: stack-s3
+      passed: [ test ]
+    - get: receipt-s3
+      passed: [ test ]
+    - get: rootfs
+      resource: cflinuxfs4
+      passed: [ test ]
+  - task: check-for-rootfs-race-condition
+    file: buildpacks-ci/tasks/check-for-rootfs-race-condition/task.yml
+
+- name: delete-deployment
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: version
+      passed: [ check-for-race-condition ]
+      trigger: true
+    - get: bbl-state
+    - get: buildpacks-ci
+  - task: create-deployment-source-config
+    file: buildpacks-ci/tasks/create-deployment-source-config/task.yml
+    params:
+      ENV_NAME: cflinuxfs4
+  - put: cflinuxfs4-rootfs-smoke-test-deployment
+    params:
+      source_file: deployment-source-config/source_file.yml
+      delete:
+        enabled: true
+        force: true
+  - put: cflinuxfs4-cf-deployment
+    params:
+      source_file: deployment-source-config/source_file.yml
+      delete:
+        enabled: true
+        force: true
+
+- name: bbl-destroy
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: cf-deployment-concourse-tasks
+      resource: cf-deployment-concourse-tasks-latest
+    - get: bbl-state
+    - get: buildpacks-ci
+    - get: version
+      passed: [ delete-deployment ]
+      trigger: true
+  - task: remove-gcp-parent-dns-record
+    file: buildpacks-ci/tasks/remove-gcp-parent-dns-record/task.yml
+    params:
+      GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
+      ENV_NAME: cflinuxfs4
+  - task: bbl-destroy
+    file: cf-deployment-concourse-tasks/bbl-destroy/task.yml
+    params:
+      BBL_STATE_DIR: cflinuxfs4
+      BBL_GCP_PROJECT_ID: cf-buildpacks
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
+    ensure:
+      put: bbl-state
+      params:
+        repository: updated-bbl-state
+        rebase: true
+
+- name: release-cflinuxfs4
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: new-cves
+      passed: [ check-for-race-condition ]
+    - get: stack-s3
+      passed: [ check-for-race-condition ]
+    - get: receipt-s3
+      passed: [ check-for-race-condition ]
+    - get: rootfs
+      resource: cflinuxfs4
+      passed: [ check-for-race-condition ]
+    - get: version
+      trigger: true
+      passed: [ check-for-race-condition ]
+      params: { bump: final }
+    - get: previous-rootfs-release
+      resource: cflinuxfs4-github-tags
+      passed: [ check-for-race-condition ]
+  - do:
+    - task: update-receipt
+      file: buildpacks-ci/tasks/update-rootfs-receipt/task.yml
+      params:
+        STACK: cflinuxfs4
+    - task: update-filename
+      file: buildpacks-ci/tasks/update-rootfs-filename/task.yml
+      params:
+        STACK: cflinuxfs4
+    - put: cflinuxfs4
+      params:
+        repository: new-rootfs-commit
+        tag: version/number
+        rebase: true
+    - put: stack-s3
+      params:
+        from: rootfs-archive/cflinuxfs4-(.*).tar.gz
+        to: /rootfs/
+    - put: version
+      params: { file: version/number }
+    on_failure: #@ failure_alert()
+
+- name: reset-minor-version-to-rc
+  serial: true
+  public: true
+  plan:
+  - get: version
+    trigger: true
+    passed: [ release-cflinuxfs4 ]
+    params: { bump: minor, pre: rc }
+  - put: version
+    params: { file: version/number }
+
+- name: upload-to-github
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: previous-rootfs-release
+      resource: cflinuxfs4-github-tags
+      passed: [ release-cflinuxfs4 ]
+    - get: rootfs
+      resource: cflinuxfs4
+      passed: [ release-cflinuxfs4 ]
+    - get: new-cves
+      passed: [ release-cflinuxfs4 ]
+    - get: stack-s3
+      passed: [ release-cflinuxfs4 ]
+    - get: version
+      trigger: true
+      passed: [ release-cflinuxfs4 ]
+  - do:
+    - task: generate-release-notes
+      file: buildpacks-ci/tasks/generate-rootfs-release-notes/task.yml
+      params:
+        STACK: cflinuxfs4
+    - put: cflinuxfs4-github-release
+      params:
+        name: version/number
+        tag: version/number
+        body: release-body/body
+        globs:
+          - stack-s3/cflinuxfs4-*.tar.gz
+    - put: new-cves
+      params:
+        repository: new-cves-artifacts
+        rebase: true
+    on_failure: #@ failure_alert()
+
+- name: finalize-security-notices
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+      resource: buildpacks-ci
+    - get: version
+      trigger: true
+      passed: [ upload-to-github ]
+  - do:
+    - task: finalize-security-notices
+      file: buildpacks-ci/tasks/finalize-security-notice-stories/task.yml
+      attempts: 20
+      params:
+        TRACKER_PROJECT_ID: 2537714
+        TRACKER_REQUESTER_ID: 1431988
+        TRACKER_API_TOKEN: ((pivotal-tracker-api-token))
+        STACK: cflinuxfs4
+
+- name: upload-to-docker
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: stack-s3
+      passed: [ release-cflinuxfs4 ]
+    - get: version
+      trigger: true
+      passed: [ release-cflinuxfs4 ]
+  - do:
+    - task: rename
+      file: buildpacks-ci/tasks/rename-rootfs-for-docker/task.yml
+      params:
+        STACK: cflinuxfs4
+    - in_parallel:
+      - put: cflinuxfs4-image
+        params:
+          skip_download: true
+          import_file: docker-s3/cflinuxfs4.tar.gz
+          tag: version/number
+          tag_as_latest: true
+    on_failure: #@ failure_alert()
+
+- name: create-cflinuxfs4-release
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: blob
+      resource: stack-s3
+      passed: [ release-cflinuxfs4 ]
+      trigger: true
+    - get: version
+      passed: [ release-cflinuxfs4 ]
+    - get: release
+      resource: cflinuxfs4-release
+  - do:
+    - task: create-cflinuxfs4-release
+      file: buildpacks-ci/tasks/rootfs/create-release/task.yml
+      params:
+        BLOB_NAME: rootfs
+        BLOB_GLOB: blob/cflinuxfs4-*.tar.gz
+        RELEASE_NAME: cflinuxfs4
+        ACCESS_KEY_ID: ((cloudfoundry-s3-access-key))
+        SECRET_ACCESS_KEY: ((cloudfoundry-s3-secret-key))
+    - task: create-release-body
+      file: buildpacks-ci/tasks/create-rootfs-bosh-release-github-release-notes/task.yml
+      params:
+        STACK: cflinuxfs4
+    - task: create-release-commit
+      file: buildpacks-ci/tasks/create-rootfs-bosh-release-commit/task.yml
+    - put: cflinuxfs4-release
+      params:
+        repository: release-artifacts
+    - put: cflinuxfs4-release-github-release
+      params:
+        name: version/number
+        tag: version/number
+        tag_prefix: v
+        commitish: release-commit/sha
+        body: release-body/body
+        globs:
+          - release-artifacts/releases/cflinuxfs4/*.tgz
+    on_failure: #@ failure_alert()


### PR DESCRIPTION
cflinuxfs4 CF stack pipeline that runs at https://buildpacks.ci.cf-app.com/teams/core-deps/pipelines/cflinuxfs4

Similar to the cflinuxfs3 pipeline expect for the following
differences:

- Deploy testing: buildpacks are not installed in the CF since buildpack
bosh releases for cflinuxfs4 are not yet available

- CATS is not used. Minimal testing is accomplished by building
https://github.com/cloudfoundry/go-buildpack/tree/hacky-cflinuxfs4 and
pushing go-mod app

- Needs garden-runc-release >= 1.20.7 due to
https://github.com/cloudfoundry/garden-runc-release/pull/229