### PR TITLE
Dockerfile: update cf cli from v7 to v8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN curl -sL "https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key"
 
 RUN apt-get -qqy update \
   && apt-get -qqy install \
-    cf7-cli \
+    cf8-cli \
     git \
     jq \
     unzip \


### PR DESCRIPTION
It looks like https://github.com/cloudfoundry/cf-acceptance-tests/releases/tag/v9.2.0 needs cf cli 7

Log: https://buildpacks-private.ci.cf-app.com/teams/core-deps/pipelines/tas/jobs/cats/builds/647#L6359335f:110