### PR TITLE
cf-release pipeline: add attempts to CATs

### DIFF
--- a/pipelines/cf-release/cf-release.yml
+++ b/pipelines/cf-release/cf-release.yml
@@ -308,6 +308,7 @@ jobs:
       toolsmiths-env: cf-deployment-env
   - task: run-cats
     file: cf-deployment-concourse-tasks/run-cats/task.yml
+    attempts: 3
     input_mapping:
       integration-config: cats-integration-config
       toolsmiths-env: cf-deployment-env


### PR DESCRIPTION
If you see the history of the pipeline
https://buildpacks.ci.cf-app.com/teams/core-deps/pipelines/cf-release/jobs/cats/builds/1071, there has been occassional failures that has gone away with reruns. Try 3 times before it fails.

By schedule, this is an overnight job (3AM eastern all weekdays) - so it shouldn't cause the CI too much strain due to reruns.