### PR TITLE
consolidate CI image

### DIFF
--- a/tasks/cf-release/upload-bosh-release/task.yml
+++ b/tasks/cf-release/upload-bosh-release/task.yml
@@ -3,7 +3,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: coredeps/core-deps-ci
+    repository: cfbuildpacks/ci
+    tag: latest
 inputs:
 - name: core-deps-ci
 - name: cf-deployment-concourse-tasks


### PR DESCRIPTION
Same reason as https://github.com/cloudfoundry/buildpacks-feature-eng-ci/pull/7

To address failure in https://buildpacks.ci.cf-app.com/teams/core-deps/pipelines/cf-release/jobs/deploy/builds/1002#L63de35c4:4