### PR TITLE
Update the ci used in the task from coredeps/ci to cfbuildpacks/ci

### DIFF
--- a/tasks/cf-release/create-cats-integration-config/task.yml
+++ b/tasks/cf-release/create-cats-integration-config/task.yml
@@ -3,12 +3,13 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: coredeps/core-deps-ci
+    repository: cfbuildpacks/ci
+    tag: latest
 inputs:
-- name: core-deps-ci
-- name: cf-deployment-concourse-tasks
-- name: toolsmiths-env
+  - name: core-deps-ci
+  - name: cf-deployment-concourse-tasks
+  - name: toolsmiths-env
 outputs:
-- name: cats-integration-config
+  - name: cats-integration-config
 run:
   path: core-deps-ci/tasks/cf-release/create-cats-integration-config/run


### PR DESCRIPTION
# Context

Let's try to use the image cfbuildpacks/ci:latest (src) when possible. Having a lot of CI images are unmanageable. This happened because in the past these were managed by many teams and each team made their own CI image(s)

Related to #33 changes.
