### PR TITLE
cflinuxfs4 test: loosen log assertion

### DIFF
--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -434,7 +434,7 @@ jobs:
               cf create-buildpack go_cflinuxfs4 ./build/buildpack.zip 1
 
               cf push gomodapp -p fixtures/mod/simple -b go_cflinuxfs4 -s cflinuxfs4 | tee /tmp/cfpushlog
-              if ! grep -q "Description:\s*Ubuntu\s*22.04*" "/tmp/cfpushlog"; then
+              if ! grep -q "Ubuntu\s*22.04*" "/tmp/cfpushlog"; then
                 echo "cf push logs did not print out 'Ubuntu 22.04'" >&2
                 exit 1
               fi


### PR DESCRIPTION
In the cflinuxfs4 pipeline test job, loosen the log assertion for OS information so it's not dependent on whether we get that information from running `lsb_release -a` or `cat /etc/os-release`