### PR TITLE
cflinuxfs4 test: assert that ruby and python3 are not present

### DIFF
--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -439,6 +439,18 @@ jobs:
                 exit 1
               fi
 
+              # stack should not contain python3 (libpython3 is OK)
+              if grep -q "^\s*python3" "/tmp/cfpushlog"; then
+                echo "Packages installed should not contain `python3`" >&2
+                exit 1
+              fi
+
+              # stack should not contain ruby (libruby is OK)
+              if grep -q "^\s*ruby" "/tmp/cfpushlog"; then
+                echo "Packages installed should not contain `ruby`" >&2
+                exit 1
+              fi
+
               result=$(curl -s "gomodapp.${apps_domain}" | head -n1)
               if [ "${result}" != "go, world" ]; then
                 echo "Unexpected result: ${result}" >&2


### PR DESCRIPTION
We removed ruby and python from the cflinuxfs4 stack image. We should assert in the test output that those packages are no longer there.

BTW, these tests depend on the https://github.com/cloudfoundry/go-buildpack/compare/hacky-cflinuxfs4 branch of the Go buildpack for testing, which includes code to list out all packages installed on the image... I can file a separate issue to straighten out how we test the stack.