### PR TITLE
Pin latest working version of cf-acceptance-tests

### DIFF
--- a/pipelines/cf-release/cf-release.yml
+++ b/pipelines/cf-release/cf-release.yml
@@ -38,7 +38,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-acceptance-tests
-    branch: main
+    branch: v11.1.0
 
 - name: cf-deployment-env
   type: toolsmiths-envs


### PR DESCRIPTION
# Context

The current CAPI and Diego versions that we have available in our environments are:
```
> bosh deployments
Name  Release(s)                              Stemcell(s)                                 Team(s)                                                            
      capi/1.144.0                                                                                                                               
      diego/2.71.0                                                                          
```

And the latest `cf-acceptance-test` release [v12.0.0](https://github.com/cloudfoundry/cf-acceptance-tests/releases/tag/v12.0.0) requires `CAPI v1.147.0` and `Diego v2.72.0` (mentioned as a breaking change).

# Solution

As a temporary solution, we pin the version to the latest one that works. This should be changed once we met the CAPI ad Diego requirements.